### PR TITLE
Update m150731_150101_create_page_table.php

### DIFF
--- a/migrations/m150731_150101_create_page_table.php
+++ b/migrations/m150731_150101_create_page_table.php
@@ -47,8 +47,8 @@ class m150731_150101_create_page_table extends Migration
 
     public function safeDown()
     {
-        $this->dropForeignKey('fk_page_created_by', self::PAGE_TABLE);
-        $this->dropForeignKey('fk_page_updated_by', self::PAGE_TABLE);
+        //$this->dropForeignKey('fk_page_created_by', self::PAGE_TABLE);
+        //$this->dropForeignKey('fk_page_updated_by', self::PAGE_TABLE);
         $this->dropForeignKey('fk_page_lang', self::PAGE_LANG_TABLE);
         $this->dropTable(self::PAGE_LANG_TABLE);
         $this->dropTable(self::PAGE_TABLE);


### PR DESCRIPTION
migration/down command fails in this file because the lines 50-51 of safeDown method try to drop foreign keys that never have been created.